### PR TITLE
ITPL-11947: Removing rollingstats about routes

### DIFF
--- a/web.js
+++ b/web.js
@@ -172,10 +172,6 @@ module.exports = function( options ) {
         stats[name] = {}
       })
 
-      _.each( timestats.names(), function(name) {
-        stats[name] = timestats.calculate(name)
-      })
-
       done(null,stats)
     })
   }
@@ -591,9 +587,6 @@ function makedispatch(act,spec,urlspec,handlerspec,timestats) {
     var respond = function(err,obj){
       var qi = req.url.indexOf('?')
       var url = -1 == qi ? req.url : req.url.substring(0,qi)
-      var name = (spec.plugin$ && spec.plugin$.name) || '-'
-      timestats.point( Date.now()-begin, name+';'+req.method+';'+url );
-
       responder.call(si,req,res,handlerspec,err,obj)
     }
 


### PR DESCRIPTION
#### Original issue (Brief description of original problem)
- `seneca-web` was using a module `rolling-stats` to collect time metrics around routes. This was causing a leak as the internal map would grow.

#### Changes proposed (Brief description of solution and how it addresses the problem)
- Removed the usage of `rolling-stats`, we don't need it and it's the quickest way to test if this fixes the memory leak we're facing

@i-Sight/product-team
