### PR TITLE
sanitizeURIComponents: add sanitizer when extracting data from URI

### DIFF
--- a/http-router.js
+++ b/http-router.js
@@ -13,6 +13,7 @@
  */
 
 var parse = require('url').parse;
+var sanitizeHtml = require('html-css-sanitizer').sanitize;
 
 /**
  * Expose router.
@@ -351,7 +352,7 @@ function match(req, routes, i) {
         var j
         for (j = 1, len = captures.length; j < len; ++j) {
           var key = keys[j-1],
-            val = typeof captures[j] === 'string' ? decodeURIComponent(captures[j]) : captures[j];
+            val = typeof captures[j] === 'string' ? sanitizeHtml(decodeURIComponent(captures[j])) : captures[j];
           if (key) {
             fn.params[key] = val;
           } else {

--- a/package.json
+++ b/package.json
@@ -25,15 +25,16 @@
     "web"
   ],
   "dependencies": {
-    "underscore": "~1.6.0",
-    "mstring": "~0.1.2",
-    "parambulator": "~0.1.6",
     "connect": "~3.6.6",
+    "html-css-sanitizer": "git://github.com/i-Sight/node-caja-sanitizer.git#v0.0.3",
     "json-stringify-safe": "~5.0.0",
+    "mstring": "~0.1.2",
     "nid": "~0.3.2",
+    "parambulator": "~0.1.6",
+    "rolling-stats": "~0.1.0",
     "serve-static": "~1.13.2",
     "success": "~0.1.0",
-    "rolling-stats": "~0.1.0"
+    "underscore": "~1.6.0"
   },
   "devDependencies": {
     "chai": "~1.9.1",


### PR DESCRIPTION
the data extracted specifically from the URI is not being sanitized.

for example, if we have route `template/:id`, user can insert anything for the `:id` portion and it won't be sanitized. so if the user sends the this request, `/api/1.0/template/%22%3E%3Cscript%3Ealert%28%22XSS%22%29%3C%2Fscript%3E`, the `:id` portion of the URI will be decoded into `/\"><script>alert(\"XSS\")<` and it wont be sanitized

**Solution**: add forked sanitizer library in i-sight and utilize it when extracting data from the URI

